### PR TITLE
Remove test dependencies from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ setup(
     download_url='',
     keywords="money currency class abstraction",
     license='BSD',
-    install_requires=[
-        'setuptools',
-        'pytest >= 2'],
+    install_requires=[],
     classifiers=[
         'Programming Language :: Python',
         'License :: OSI Approved :: BSD License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py26
+envlist = py26,py27
 
 [testenv]
+deps=
+	pytest
 commands = py.test


### PR DESCRIPTION
There's no need for `pytest` except when testing, so we should move these test dependencies to `tox.ini`.
