### PR TITLE
Adds format for german speaking countries

### DIFF
--- a/src/moneyed/localization.py
+++ b/src/moneyed/localization.py
@@ -139,6 +139,21 @@ _format("en_US", group_size=3, group_separator=",", decimal_point=".",
                  positive_sign="", trailing_positive_sign="",
                  negative_sign="-", trailing_negative_sign="",
                  rounding_method=ROUND_HALF_EVEN)
+                 
+_format("de_DE", group_size=3, group_separator=" ", decimal_point=",",
+                 positive_sign="", trailing_positive_sign="",
+                 negative_sign="-", trailing_negative_sign="",
+                 rounding_method=ROUND_HALF_EVEN)
+                 
+_format("de_AT", group_size=3, group_separator=" ", decimal_point=",",
+                 positive_sign="", trailing_positive_sign="",
+                 negative_sign="-", trailing_negative_sign="",
+                 rounding_method=ROUND_HALF_EVEN)
+                 
+_format("de_CH", group_size=3, group_separator=" ", decimal_point=".",
+                 positive_sign="", trailing_positive_sign="",
+                 negative_sign="-", trailing_negative_sign="",
+                 rounding_method=ROUND_HALF_EVEN)
 
 _format("sv_SE", group_size=3, group_separator=" ", decimal_point=",",
                  positive_sign="", trailing_positive_sign="",


### PR DESCRIPTION
There is a little problem with de_CH, they use both. That's why at least the group separator needs to be a whitespace, to reduce confusion.
