### PR TITLE
Fix upper default critic bug

### DIFF
--- a/src/moneyed/localization.py
+++ b/src/moneyed/localization.py
@@ -36,12 +36,12 @@ class CurrencyFormatter(object):
             'rounding_method': rounding_method}
 
     def get_sign_definition(self, currency_code, locale):
-        locale = locale.upper()
         currency_code = currency_code.upper()
-        if locale in self.sign_definitions:
-            local_set = self.sign_definitions.get(locale)
-        else:
-            local_set = self.sign_definitions.get(DEFAULT)
+
+        if locale.upper() not in self.sign_definitions:
+            locale = DEFAULT
+
+        local_set = self.sign_definitions.get(locale.upper())
 
         if currency_code in local_set:
             return local_set.get(currency_code)


### PR DESCRIPTION
Fix default locale to make a query with upper version.
Leaded to a bug when an unknown locale was passed to this method. Query
was .get('default') instead of .get('DEFAULT').
@limist 

Example:

> > > from moneyed.localization import _FORMATTER
> > > _FORMATTER.get_sign_definition('EUR', 'fr_FR')
> > > Traceback (most recent call last):
> > >   File "<input>", line 2, in <module>
> > >   File "build\bdist.win-amd64\egg\moneyed\localization.py", line 46, in get_sign_definition
> > >     if currency_code in local_set:
> > > TypeError: argument of type 'NoneType' is not iterable
