### PR TITLE
Return string from repr() that can be used by eval()

### DIFF
--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -142,7 +142,7 @@ class Money(object):
         self.currency = currency
 
     def __repr__(self):
-        return "<Money: %s %s>" % (self.amount, self.currency)
+        return "Money('%s', '%s')" % (self.amount, self.currency)
 
     def __unicode__(self):
         return format_money(self)

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -114,11 +114,15 @@ class TestMoney:
         assert one_million_dollars.amount == self.one_million_decimal
 
     def test_repr(self):
-        assert repr(self.one_million_bucks) == '<Money: 1000000 USD>'
-        assert repr(Money(Decimal('2.000'), 'PLN')) == '<Money: 2.000 PLN>'
+        assert repr(self.one_million_bucks) == "Money('1000000', 'USD')"
+        assert repr(Money(Decimal('2.000'), 'PLN')) == "Money('2.000', 'PLN')"
         m_1 = Money(Decimal('2.00'), 'PLN')
         m_2 = Money(Decimal('2.01'), 'PLN')
         assert repr(m_1) != repr(m_2)
+
+    def test_eval_from_repr(self):
+        m = Money('1000', 'USD')
+        assert m == eval(repr(m))
 
     def test_str(self):
         if PYTHON2:


### PR DESCRIPTION
Closes #140.

Unsure how to handle custom currencies passed-in directly to the `Money` class. Though, if `add_currency()` is used to create the custom currency, `eval()` will still be able to create the `Money` instance through the output of `repr`.