### PR TITLE
build: Add missing `py38` tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Add to .github/workflow/build.yml when you add to this
-envlist = py27,py35,py36,py37,py39,pypy,pypy3,flake8,checkmanifest
+envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3,flake8,checkmanifest
 
 [testenv]
 deps=


### PR DESCRIPTION
Seems like it was overlooked in 9dfb27a8341ccfd18b2a50f92885898fa2687f3f