### PR TITLE
Miscellaneous changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased - TBA
 ----------------
 
 * Changed the ``numeric`` attribute values to ``None`` for currencies that don't have assigned ISO numeric codes: ``IMP``, ``TVD``, ``XFO``, ``XFU``.
+* Restored the previous definition for the ``XXX`` currency, including its ``name`` and ``countries`` attributes.
 
 1.0 (2020-01-09)
 ----------------

--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -307,14 +307,10 @@ CURRENCIES_BY_ISO = {}
 
 
 def add_currency(code, numeric, sub_unit=1, name=None, countries=None):
-    CURRENCIES[code] = Currency(
-        code=code,
-        numeric=numeric,
-        sub_unit=sub_unit,
-        name=name,
-        countries=countries)
-    CURRENCIES_BY_ISO[numeric] = CURRENCIES[code]
-    return CURRENCIES[code]
+    currency = Currency(code=code, numeric=numeric, sub_unit=sub_unit, name=name, countries=countries)
+    CURRENCIES[code] = currency
+    CURRENCIES_BY_ISO[numeric] = currency
+    return currency
 
 
 def get_currency(code=None, iso=None):

--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -307,7 +307,6 @@ CURRENCIES_BY_ISO = {}
 
 
 def add_currency(code, numeric, sub_unit=1, name=None, countries=None):
-    global CURRENCIES
     CURRENCIES[code] = Currency(
         code=code,
         numeric=numeric,

--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -524,10 +524,9 @@ XXX = add_currency(
     '999',
     # For backwards compat we keep values here, instead of getting
     # Babel's data.
-    'The codes assigned for transactions where no currency is involved',
-    ['ZZ07_No_Currency'],
+    name='The codes assigned for transactions where no currency is involved',
+    countries=['ZZ07_No_Currency'],
 )
-XXX = add_currency('XXX', '999')
 YER = add_currency('YER', '886', 100)
 ZAR = add_currency('ZAR', '710', 100)
 ZMW = add_currency('ZMW', '967', 100)


### PR DESCRIPTION
Changes in `add_currency` are mostly cleaning up & minor perf improvements.

For `XXX` it restores proper `name` and `countries` data - probably was an oversight in 19e8824135c2c5c4e8ab8f769f692ecb2a7b1ab3, as the next line was overriding that currency instance from the previous line. 

It also fixes the problem with `subunit` - as positional arguments were used, the `subunit` attribute got a string value