### PR TITLE
Drop Python 3.6, introduce Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,4 +37,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,38 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v3.4.0"
+    rev: "v4.1.0"
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/sirosen/check-jsonschema
-    rev: "0.3.0"
+    rev: "0.9.1"
     hooks:
     -   id: check-github-workflows
         require_serial: true
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: "3.9.1"
+    rev: "3.9.2"
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: "v5.8.0"
+    rev: "v5.10.1"
     hooks:
     -   id: isort
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.46"
+    rev: "0.47"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/asottile/pyupgrade
-    rev: "v2.12.0"
+    rev: "v2.31.0"
     hooks:
     -   id: pyupgrade
         args:
-        - --py36-plus
+        - --py37-plus
 -   repo: https://github.com/psf/black
-    rev: "20.8b1"
+    rev: "21.12b0"
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.812"
+    rev: "v0.930"
     hooks:
     -   id: mypy
         args: []

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,14 +39,14 @@ To run the test suite, first install tox (into your virtualenv)::
 
 Run the tests using tox::
 
-  tox -e py39
+  tox -e py310
 
 You can run the test suite on all supported environments using tox_
 (recommended). If you do not have all versions of Python that are used in
 testing, you can use pyenv_ to install them, and you may benefit from the
 additional plugin pyenv-implict_.
 
-The py-moneyed package is tested against Python 3.6 - 3.9 and PyPy 3.
+The py-moneyed package is tested against Python 3.7 - 3.10 and PyPy 3.
 
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _pyenv: https://github.com/pyenv/pyenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,10 @@ license = BSD
 platforms = any
 classifiers =
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: BSD License
@@ -35,7 +35,7 @@ packages = find:
 package_dir =
     =src
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     babel>=2.8.0
     typing-extensions>=3.7.4.3
@@ -74,7 +74,7 @@ norecursedirs =
     .mypy_cache
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 show_error_codes = True
 pretty = True
 files = src/, tests/

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -404,11 +404,9 @@ def get_currencies_of_country(country_code: str) -> List[Currency]:
     """
     country_code = country_code.upper()
     return sorted(
-        [
-            currency
-            for currency in CURRENCIES.values()
-            if country_code in currency.country_codes
-        ]
+        currency
+        for currency in CURRENCIES.values()
+        if country_code in currency.country_codes
     )
 
 

--- a/tests/test_money.yaml
+++ b/tests/test_money.yaml
@@ -5,13 +5,13 @@
     Money(amount=10)
   out: |
     main:2: error: No overload variant of "Money" matches argument type "int"  [call-overload]
+    main:2: note: Possible overload variants:
     main:2: note:     def __init__(self, amount: object = ..., *, currency: Union[str, Currency]) -> Money
     main:2: note:     def __init__(self, amount: object, currency: Union[str, Currency]) -> Money
-    main:2: note: Possible overload variants:
     main:3: error: No overload variant of "Money" matches argument type "int"  [call-overload]
+    main:3: note: Possible overload variants:
     main:3: note:     def __init__(self, amount: object = ..., *, currency: Union[str, Currency]) -> Money
     main:3: note:     def __init__(self, amount: object, currency: Union[str, Currency]) -> Money
-    main:3: note: Possible overload variants:
   # A bug in mypy seems to make it so that on non-cached runs the output uses __init__
   # and on cached runs it uses Money. Disabling the cache seems to make the output
   # stable.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Add to .github/workflow/build.yml and [gh-actions] below when you add to this
-envlist = py36,py37,py38,py39,pypy3
+envlist = py37,py38,py39,py310,pypy3
 isolated_build = true
 
 [testenv]
@@ -15,11 +15,11 @@ commands = pytest
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
-    pypy3: pypy3
+    3.10: py310
+    pypy-3.8: pypy3
 
 [testenv:build]
 deps = build


### PR DESCRIPTION
- Bump pre-commit dependencies.
- Fix new expected order of output lines in type test.
- Declare Python versions as strings in build.yaml (failing to do so caused 3.10 to be interpreted as 3.1 😅).
- Bump tested pypy version to pypy-3.8.