### PR TITLE
Upgrade type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
     hooks:
       - id: pyupgrade
         args:
+          - --py3-plus
+          - --py36-plus
           - --py37-plus
   - repo: https://github.com/psf/black
     rev: "21.12b0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
           - --py3-plus
           - --py36-plus
           - --py37-plus
-          - --keep-runtime-typing
   - repo: https://github.com/psf/black
     rev: "21.12b0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
           - --py3-plus
           - --py36-plus
           - --py37-plus
+          - --keep-runtime-typing
   - repo: https://github.com/psf/black
     rev: "21.12b0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.1.0"
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
--   repo: https://github.com/sirosen/check-jsonschema
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/sirosen/check-jsonschema
     rev: "0.9.1"
     hooks:
-    -   id: check-github-workflows
+      - id: check-github-workflows
         require_serial: true
--   repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8
     rev: "3.9.2"
     hooks:
-    -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-isort
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: "v5.10.1"
     hooks:
-    -   id: isort
--   repo: https://github.com/mgedmin/check-manifest
+      - id: isort
+  - repo: https://github.com/mgedmin/check-manifest
     rev: "0.47"
     hooks:
-    -   id: check-manifest
--   repo: https://github.com/asottile/pyupgrade
+      - id: check-manifest
+  - repo: https://github.com/asottile/pyupgrade
     rev: "v2.31.0"
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args:
-        - --py37-plus
--   repo: https://github.com/psf/black
+          - --py37-plus
+  - repo: https://github.com/psf/black
     rev: "21.12b0"
     hooks:
-    -   id: black
--   repo: https://github.com/pre-commit/mirrors-mypy
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.930"
     hooks:
-    -   id: mypy
-        args: []
+      - id: mypy
+        args: [ ]
         exclude: ^(docs/|setup.py$)
         additional_dependencies:
-            - pytest
+          - pytest

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,12 +1,10 @@
-from typing import Dict
-
 import pytest
 
 from moneyed import USD, Money
 
 
 @pytest.fixture(autouse=True)
-def add_entities(doctest_namespace: Dict[str, object]) -> None:
+def add_entities(doctest_namespace: dict[str, object]) -> None:
     """
     Inserts entities into doctest namespaces so that imports don't have to be added to
     all examples.

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,8 @@ type-tests =
 
 [flake8]
 max-line-length = 119
+per-file-ignores =
+    src/moneyed/__init__.py:F403,F401
 
 [isort]
 profile = black

--- a/src/moneyed/__init__.py
+++ b/src/moneyed/__init__.py
@@ -1,1 +1,1 @@
-from .classes import *  # NOQA
+from .classes import *

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import warnings
 from decimal import Decimal
-from typing import Any, Dict, List, NoReturn, Optional, TypeVar, Union, overload
+from typing import Any, NoReturn, Optional, TypeVar, Union, overload
 
 from babel import Locale
 from babel.core import get_global
@@ -31,7 +33,7 @@ class Currency:
         numeric: Optional[str] = None,
         sub_unit: int = 1,
         name: Optional[str] = None,
-        countries: Optional[List[str]] = None,
+        countries: Optional[list[str]] = None,
     ) -> None:
         self.code: Final = code
         self.numeric: Final = numeric
@@ -54,10 +56,10 @@ class Currency:
     def __repr__(self) -> str:
         return self.code
 
-    def __lt__(self, other: "Currency") -> bool:
+    def __lt__(self, other: Currency) -> bool:
         return self.code < other.code
 
-    def __le__(self, other: "Currency") -> bool:
+    def __le__(self, other: Currency) -> bool:
         return self.code <= other.code
 
     @cached_property
@@ -81,11 +83,11 @@ class Currency:
         )
 
     @cached_property
-    def zero(self) -> "Money":
+    def zero(self) -> Money:
         return Money(0, self)
 
     @cached_property
-    def countries(self) -> List[str]:
+    def countries(self) -> list[str]:
         """
         List of country names, uppercased and in US locale, where the currency is
         used at present.
@@ -102,7 +104,7 @@ class Currency:
         ]
 
     @cached_property
-    def country_codes(self) -> List[str]:
+    def country_codes(self) -> list[str]:
         """
         List of current country codes for the currency.
         """
@@ -352,8 +354,8 @@ class Money:
 # Definitions of ISO 4217 Currencies
 # Source: http://www.iso.org/iso/support/faqs/faqs_widely_used_standards/widely_used_standards_other/currency_codes/currency_codes_list-1.htm  # noqa
 
-CURRENCIES: Dict[str, Currency] = {}
-CURRENCIES_BY_ISO: Dict[str, Currency] = {}
+CURRENCIES: dict[str, Currency] = {}
+CURRENCIES_BY_ISO: dict[str, Currency] = {}
 
 
 def add_currency(
@@ -361,7 +363,7 @@ def add_currency(
     numeric: Optional[str],
     sub_unit: int = 1,
     name: Optional[str] = None,
-    countries: Optional[List[str]] = None,
+    countries: Optional[list[str]] = None,
 ) -> Currency:
     currency = Currency(
         code=code, numeric=numeric, sub_unit=sub_unit, name=name, countries=countries
@@ -394,7 +396,7 @@ def get_currency(
         raise CurrencyDoesNotExist(code)
 
 
-def get_currencies_of_country(country_code: str) -> List[Currency]:
+def get_currencies_of_country(country_code: str) -> list[Currency]:
     """
     Returns list with currency object(s) given the country's ISO-2 code.
     Raises a CountryDoesNotExist exception if the country is not found.
@@ -410,7 +412,7 @@ def get_currencies_of_country(country_code: str) -> List[Currency]:
     )
 
 
-def list_all_currencies() -> List[Currency]:
+def list_all_currencies() -> list[Currency]:
     return sorted(CURRENCIES.values(), key=lambda c: c.code)
 
 

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from decimal import Decimal
-from typing import Any, NoReturn, Optional, TypeVar, Union, overload
+from typing import Any, NoReturn, TypeVar, overload
 
 from babel import Locale
 from babel.core import get_global
@@ -30,10 +30,10 @@ class Currency:
     def __init__(
         self,
         code: str = "",
-        numeric: Optional[str] = None,
+        numeric: str | None = None,
         sub_unit: int = 1,
-        name: Optional[str] = None,
-        countries: Optional[list[str]] = None,
+        name: str | None = None,
+        countries: list[str] | None = None,
     ) -> None:
         self.code: Final = code
         self.numeric: Final = numeric
@@ -73,7 +73,7 @@ class Currency:
             return self._name
         return self.get_name("en_US")
 
-    def get_name(self, locale: str, count: Optional[int] = None) -> str:
+    def get_name(self, locale: str, count: int | None = None) -> str:
         from babel.numbers import get_currency_name
 
         return get_currency_name(  # type: ignore[no-any-return]
@@ -133,7 +133,7 @@ class MoneyComparisonError(TypeError):
 
 
 class CurrencyDoesNotExist(Exception):
-    def __init__(self, code: Optional[str]) -> None:
+    def __init__(self, code: str | None) -> None:
         super().__init__(f"No currency with code {code} is defined.")
 
 
@@ -163,17 +163,17 @@ class Money:
     # the implementation defines `None` as default for currency, but raises a TypeError
     # for that case.
     @overload
-    def __init__(self, amount: object = ..., *, currency: Union[str, Currency]) -> None:
+    def __init__(self, amount: object = ..., *, currency: str | Currency) -> None:
         ...
 
     @overload
-    def __init__(self, amount: object, currency: Union[str, Currency]) -> None:
+    def __init__(self, amount: object, currency: str | Currency) -> None:
         ...
 
     def __init__(
         self,
         amount: object = Decimal("0.0"),
-        currency: Union[str, Currency, None] = None,
+        currency: str | Currency | None = None,
     ) -> None:
         if currency is None:
             raise TypeError(
@@ -246,7 +246,7 @@ class Money:
                 currency=self.currency,
             )
 
-    def __truediv__(self: M, other: object) -> Union[M, Decimal]:
+    def __truediv__(self: M, other: object) -> M | Decimal:
         if isinstance(other, Money):
             if self.currency != other.currency:
                 raise TypeError("Cannot divide two different currencies.")
@@ -265,7 +265,7 @@ class Money:
     def __rtruediv__(self, other: object) -> NoReturn:
         raise TypeError("Cannot divide non-Money by a Money instance.")
 
-    def round(self: M, ndigits: Optional[int] = 0) -> M:
+    def round(self: M, ndigits: int | None = 0) -> M:
         """
         Rounds the amount using the current ``Decimal`` rounding algorithm.
         """
@@ -360,10 +360,10 @@ CURRENCIES_BY_ISO: dict[str, Currency] = {}
 
 def add_currency(
     code: str,
-    numeric: Optional[str],
+    numeric: str | None,
     sub_unit: int = 1,
-    name: Optional[str] = None,
-    countries: Optional[list[str]] = None,
+    name: str | None = None,
+    countries: list[str] | None = None,
 ) -> Currency:
     currency = Currency(
         code=code, numeric=numeric, sub_unit=sub_unit, name=name, countries=countries
@@ -381,13 +381,11 @@ def get_currency(code: str) -> Currency:
 
 
 @overload
-def get_currency(*, iso: Union[int, str]) -> Currency:
+def get_currency(*, iso: int | str) -> Currency:
     ...
 
 
-def get_currency(
-    code: Optional[str] = None, iso: Union[int, str, None] = None
-) -> Currency:
+def get_currency(code: str | None = None, iso: int | str | None = None) -> Currency:
     try:
         if iso:
             return CURRENCIES_BY_ISO[str(iso)]

--- a/src/moneyed/l10n.py
+++ b/src/moneyed/l10n.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
 from babel.numbers import LC_NUMERIC
 from babel.numbers import format_currency as babel_format_currency
 
 if TYPE_CHECKING:
-    from . import Money
+    from .classes import Money
 
 
 def format_money(
-    money: "Money",
+    money: Money,
     format: Optional[str] = None,
     locale: str = LC_NUMERIC,
     currency_digits: bool = True,

--- a/src/moneyed/l10n.py
+++ b/src/moneyed/l10n.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from babel.numbers import LC_NUMERIC
 from babel.numbers import format_currency as babel_format_currency
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def format_money(
     money: Money,
-    format: Optional[str] = None,
+    format: str | None = None,
     locale: str = LC_NUMERIC,
     currency_digits: bool = True,
     format_type: str = "standard",

--- a/src/moneyed/utils.py
+++ b/src/moneyed/utils.py
@@ -1,4 +1,7 @@
-from typing import Callable, Generic, TypeVar
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
 A = TypeVar("A")
 R = TypeVar("R")


### PR DESCRIPTION
Hi 🙂

This might be unwanted (did not open an issue ahead of time), so feel free to close if so. 

Otherwise, this PR just updates a little bit of linting configuration and upgrades type hints.

--------------

Relevant PEPs here include:
- [PEP563](https://www.python.org/dev/peps/pep-0563/), which makes us able to remove the quoted values for type hints defined within a `TYPE_CHECKING` block, as long as there's a `from __future__ import annotations` import present.
- [PEP585](https://www.python.org/dev/peps/pep-0585/) which lets us remove things like `typing.Dict[str, str]` in favor of `dict[str, str]`. Added for 3.8, but is backported to 3.7 with the futures annotation import.
- [PEP604](https://www.python.org/dev/peps/pep-0604/) which was added for 3.10 but was also backported to 3.7 with the futures annotation import. These annotations will cause runtime errors if evaluated at runtime though, so this upgrade is perhaps not 100% equivalent to the PEP585 one.

Type checking for both PEP585 and PEP604 style annotations is supported by mypy 👍 

--------------------

Also please let me know if, e.g., PEP585 type hints are acceptable, but 604 ones are not, and we can just drop that commit. Hope this is helpful.