### PR TITLE
Add flake8-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-print
           - flake8-mutable
           - flake8-simplify
           - flake8-pytest-style

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-pytest-style
           - flake8-printf-formatting
   - repo: https://github.com/pycqa/isort
     rev: "5.10.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-bugbear
           - flake8-comprehensions
           - flake8-print
           - flake8-mutable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
     rev: "3.9.2"
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: "v5.10.1"
+  - repo: https://github.com/pycqa/isort
+    rev: "5.10.1"
     hooks:
       - id: isort
   - repo: https://github.com/mgedmin/check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
     rev: "21.12b0"
     hooks:
       - id: black
+        args:
+          - --quiet
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.930"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
     rev: "3.9.2"
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-type-checking
   - repo: https://github.com/pycqa/isort
     rev: "5.10.1"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-simplify
           - flake8-pytest-style
           - flake8-printf-formatting
   - repo: https://github.com/pycqa/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-printf-formatting
   - repo: https://github.com/pycqa/isort
     rev: "5.10.1"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-mutable
           - flake8-simplify
           - flake8-pytest-style
           - flake8-printf-formatting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,25 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: "21.12b0"
+    hooks:
+      - id: black
+        args:
+          - --quiet
+
+  - repo: https://github.com/pycqa/isort
+    rev: "5.10.1"
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: "v2.31.0"
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py3-plus
+          - --py36-plus
+          - --py37-plus
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.1.0"
     hooks:
@@ -6,11 +27,13 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending
+
   - repo: https://github.com/sirosen/check-jsonschema
     rev: "0.9.1"
     hooks:
       - id: check-github-workflows
         require_serial: true
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: "3.9.2"
     hooks:
@@ -24,28 +47,7 @@ repos:
           - flake8-simplify
           - flake8-pytest-style
           - flake8-printf-formatting
-  - repo: https://github.com/pycqa/isort
-    rev: "5.10.1"
-    hooks:
-      - id: isort
-  - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.47"
-    hooks:
-      - id: check-manifest
-  - repo: https://github.com/asottile/pyupgrade
-    rev: "v2.31.0"
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py3-plus
-          - --py36-plus
-          - --py37-plus
-  - repo: https://github.com/psf/black
-    rev: "21.12b0"
-    hooks:
-      - id: black
-        args:
-          - --quiet
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.930"
     hooks:
@@ -53,3 +55,8 @@ repos:
         exclude: ^(docs/|setup.py$)
         additional_dependencies:
           - pytest
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.47"
+    hooks:
+      - id: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,6 @@ repos:
     rev: "v0.930"
     hooks:
       - id: mypy
-        args: [ ]
         exclude: ^(docs/|setup.py$)
         additional_dependencies:
           - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-type-checking
+          - flake8-comprehensions
           - flake8-print
           - flake8-mutable
           - flake8-simplify

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,10 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.1.0"
     hooks:
+      - id: check-ast
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: mixed-line-ending
   - repo: https://github.com/sirosen/check-jsonschema
     rev: "0.9.1"
     hooks:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,7 +4,7 @@ from moneyed import USD, Money
 
 
 @pytest.fixture(autouse=True)
-def add_entities(doctest_namespace: dict[str, object]) -> None:
+def _add_entities(doctest_namespace: dict[str, object]) -> None:
     """
     Inserts entities into doctest namespaces so that imports don't have to be added to
     all examples.

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ type-tests =
 
 [flake8]
 max-line-length = 119
+enable-extensions = TC, TC1
 per-file-ignores =
     src/moneyed/__init__.py:F403,F401
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,11 @@ max-line-length = 119
 enable-extensions = TC, TC1
 per-file-ignores =
     src/moneyed/__init__.py:F403,F401
+ignore =
+    # W503 - Incompatible with Black
+    W503,
+    # SIM106 - Ignore error cases first
+    SIM106,
 
 [isort]
 profile = black

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -152,6 +152,9 @@ class SupportsNeg(Protocol):
         ...
 
 
+zero = Decimal("0.0")
+
+
 class Money:
     """
     A Money instance is a combination of data - an amount and a
@@ -177,7 +180,7 @@ class Money:
 
     def __init__(
         self,
-        amount: object = Decimal("0.0"),
+        amount: object = zero,
         currency: str | Currency | None = None,
     ) -> None:
         if currency is None:

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import warnings
 from decimal import Decimal
-from typing import Any, NoReturn, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 from babel import Locale
 from babel.core import get_global
-from typing_extensions import Final, Protocol
+from typing_extensions import Protocol
 
 from .l10n import format_money
 from .utils import cached_property
+
+if TYPE_CHECKING:
+    from typing import Any, NoReturn
+
+    from typing_extensions import Final
 
 
 def force_decimal(amount: object) -> Decimal:

--- a/src/moneyed/utils.py
+++ b/src/moneyed/utils.py
@@ -17,7 +17,7 @@ class cached_property(Generic[A, R]):
 
     def __init__(self, func: Callable[[A], R]) -> None:
         self.func = func
-        self.__doc__ = getattr(func, "__doc__")
+        self.__doc__ = func.__doc__
 
     def __get__(self, instance: A, type: type) -> R:
         res = instance.__dict__[self.func.__name__] = self.func(instance)

--- a/src/moneyed/utils.py
+++ b/src/moneyed/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 A = TypeVar("A")
 R = TypeVar("R")

--- a/tests/test_moneyed_classes.py
+++ b/tests/test_moneyed_classes.py
@@ -411,5 +411,5 @@ def test_all_babel_currencies():
 def test_list_all_currencies():
     all_currencies = list_all_currencies()
     assert len(all_currencies) > 100
-    assert [c.code for c in all_currencies[0:3]] == ["ADP", "AED", "AFA"]
+    assert [c.code for c in all_currencies[:3]] == ["ADP", "AED", "AFA"]
     assert all(isinstance(c, Currency) for c in all_currencies)

--- a/tests/test_moneyed_classes.py
+++ b/tests/test_moneyed_classes.py
@@ -400,9 +400,7 @@ class ExtendedMoney(Money):
 
 
 def test_all_babel_currencies():
-    missing = sorted(
-        list(set(get_global("all_currencies").keys()) - set(CURRENCIES.keys()))
-    )
+    missing = sorted(set(get_global("all_currencies").keys()) - set(CURRENCIES.keys()))
     assert (
         missing == []
     ), "The following currencies defined in Babel are missing: " + ", ".join(missing)


### PR DESCRIPTION
Relates to discussion in #174.

PR adds flake8-hooks (and relevant small fixes) to the project's pre-commit config.

In addition to the hooks + fixes, I've taken the liberty of making some unrelated small changes, including:
- Adding a `--quiet` argument to black's arguments (to silence pre-commit output)
- Removing a redundant `args` definition for the mypy hook
- Replacing the isort hook URL with the new PSF one
- Adding two additional pre-commit-hooks hooks
- Re-ordering the pre-commit hooks

If you prefer I revert one or more of these, let me know 👍 