### PR TITLE
Run CI on Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,19 +13,14 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      with:
-          path: ~/.cache/pip
-          key: >-
-            ${{ runner.os }}
-            -pip
-            -${{ matrix.python-version }}
-            -${{ hashFiles('setup.cfg') }}
+        cache: pip
+        cache-dependency-path: setup.cfg
+        check-latest: true
     - name: Install dependencies
       run: python -m pip install --upgrade pip tox tox-gh-actions
     - name: Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Add to .github/workflow/build.yml and [gh-actions] below when you add to this
-envlist = py37,py38,py39,py310,311,pypy3
+envlist = py37,py38,py39,py310,py311,pypy3
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
Update to use latest versions of GH actions, including setup-python which now supports pip caching out of the box.