### PR TITLE
feat: MoneyRange class to handle ranges

### DIFF
--- a/src/moneyed/l10n.py
+++ b/src/moneyed/l10n.py
@@ -6,7 +6,7 @@ from babel.numbers import LC_NUMERIC
 from babel.numbers import format_currency as babel_format_currency
 
 if TYPE_CHECKING:
-    from .classes import Money
+    from .classes import Money, MoneyRange
 
 
 def format_money(
@@ -29,3 +29,33 @@ def format_money(
         format_type=format_type,
         decimal_quantization=decimal_quantization,
     )
+
+
+def format_money_range(
+    money: MoneyRange,
+    format: str | None = None,
+    locale: str = LC_NUMERIC,
+    currency_digits: bool = True,
+    format_type: str = "standard",
+    decimal_quantization: bool = True,
+) -> str:
+    """
+    See https://babel.pocoo.org/en/latest/api/numbers.html
+    """
+    arr =  list(
+        map(
+            lambda x: babel_format_currency(
+                x,
+                money.currency.code,
+                format=format,
+                locale=locale,
+                currency_digits=currency_digits,
+                format_type=format_type,
+                decimal_quantization=decimal_quantization,
+            ),
+            money.amount
+        )
+    )
+    if len(arr) > 1:
+        return f"{arr[0]} to {arr[1]}"
+    return arr[0]

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -1,13 +1,19 @@
-from moneyed import Money
-from moneyed.l10n import format_money
+from moneyed import Money, MoneyRange
+from moneyed.l10n import format_money, format_money_range
 
 one_million_bucks = Money("1000000", "USD")
 one_million_eur = Money("1000000", "EUR")
+one_million_bucks_to_two_million_bucks = MoneyRange(["1000000", "2000000"], "USD")
+one_million_eur_to_two_million_eur = MoneyRange(["1000000", "2000000"], "EUR")
 
 
 def test_format_money():
     assert format_money(one_million_bucks, locale="en_US") == "$1,000,000.00"
     assert format_money(one_million_eur, locale="en_US") == "€1,000,000.00"
+
+def test_format_money_range():
+    assert format_money_range(one_million_bucks_to_two_million_bucks, locale="en_US") == "$1,000,000.00 to $2,000,000.00"
+    assert format_money_range(one_million_eur_to_two_million_eur, locale="en_US") == "€1,000,000.00 to €2,000,000.00"
 
 
 # Test a few things are being passed on. But don't test everything, it is tested in Babel
@@ -17,4 +23,12 @@ def test_format_money_decimal_quantization():
     assert (
         format_money(Money("2.0123", "USD"), locale="en_US", decimal_quantization=False)
         == "$2.0123"
+    )
+
+
+def test_format_money_range_decimal_quantization():
+    amount = ["10.4567", "20.0123"]
+    assert (
+        format_money_range(MoneyRange(amount, "USD"), locale="en_US", decimal_quantization=False)
+        == "$10.4567 to $20.0123"
     )

--- a/tests/test_moneyed_classes.py
+++ b/tests/test_moneyed_classes.py
@@ -10,7 +10,9 @@ from moneyed.classes import (
     USD,
     Currency,
     Money,
+    MoneyRange,
     MoneyComparisonError,
+    MoneyRangeComparisonError,
     force_decimal,
     get_currencies_of_country,
     get_currency,
@@ -394,7 +396,301 @@ class TestMoney:
         assert result == Money("4.875", "GBP")
 
 
+class TestMoneyRange:
+    def setup_method(self, method):
+        self.million_range_decimal = [Decimal("1000000"), Decimal("2000000")]
+        self.USD = CURRENCIES["USD"]
+        self.one_million_bucks = MoneyRange(
+            amount=self.million_range_decimal, currency=self.USD
+        )
+
+    def test_init(self):
+        million_range_dollars = MoneyRange(amount=self.million_range_decimal, currency=self.USD)
+        assert million_range_dollars.amount == self.million_range_decimal
+        assert million_range_dollars.currency == self.USD
+
+    def test_init_string_currency_code(self):
+        one_million_dollars = MoneyRange(amount=self.million_range_decimal, currency="usd")
+        assert one_million_dollars.amount == self.million_range_decimal
+        assert one_million_dollars.currency == self.USD
+
+    def test_init_omit_currency(self):
+        with pytest.raises(
+            TypeError,
+            match=r"__init__\(\) missing 1 required positional argument: 'currency'",
+        ):
+            MoneyRange(amount=self.million_range_decimal)
+
+    def test_init_float(self):
+        million_range_dollars = MoneyRange(amount=[1000000.0, 2000000.0], currency="PEN")
+        assert million_range_dollars.amount == self.million_range_decimal
+
+    def test_repr(self):
+        assert repr(self.one_million_bucks) == "MoneyRange(['1000000', '2000000'], 'USD')"
+        assert repr(MoneyRange([Decimal("2.000"), Decimal("3.000")], "PLN")) == "MoneyRange(['2.000', '3.000'], 'PLN')"
+        m_1 = MoneyRange([Decimal("2.00"), Decimal("3.00")], "PLN")
+        m_2 = MoneyRange([Decimal("2.01"), Decimal("3.01")], "PLN")
+        assert repr(m_1) != repr(m_2)
+
+    def test_eval_from_repr(self):
+        m = MoneyRange(["1000", "2000"], "USD")
+        assert m == eval(repr(m))
+
+    def test_str(self):
+        # Conversion to text use default locale, so results vary
+        # depending on system setup. Just assert that we don't crash.
+        assert isinstance(str(self.one_million_bucks), str)
+
+    def test_hash(self):
+        assert self.one_million_bucks in {self.one_million_bucks}
+
+    def test_add_non_money(self):
+        with pytest.raises(TypeError):
+            MoneyRange([1000, 2000]) + 123
+
+    def test_add_with_custom_class_add(self):
+        custom_class_add = CustomClassAdd()
+        assert MoneyRange([1000, 2000], "SOS") + custom_class_add == "ok"
+
+    def test_sub(self):
+        zeroed_test = self.one_million_bucks - self.one_million_bucks
+        assert zeroed_test == MoneyRange(amount=[0, 0], currency=self.USD)
+
+    def test_sub_non_money(self):
+        with pytest.raises(TypeError):
+            MoneyRange([1000, 2000]) - 123
+
+    def test_rsub_non_money(self):
+        assert 0 - MoneyRange([1, 2], currency=self.USD) == MoneyRange([-1, -2], currency=self.USD)
+        with pytest.raises(TypeError):
+            assert 1 - MoneyRange([3, 4], currency=self.USD) == MoneyRange([-1, -2], currency=self.USD)
+
+    def test_mul(self):
+        x = MoneyRange(amount=[111.33, 222.33], currency=self.USD)
+        assert 3 * x == MoneyRange([333.99, 666.99], currency=self.USD)
+        assert MoneyRange([333.99, 666.99], currency=self.USD) == 3 * x
+
+    def test_mul_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            MoneyRange(["10", "20"], currency="ZMW") * 1.2
+            assert "Multiplying MoneyRange instances with floats is deprecated" in [
+                w.message.args[0] for w in warning_list
+            ]
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            1.2 * MoneyRange(amount=["10", "20"], currency="XAG")
+            assert "Multiplying MoneyRange instances with floats is deprecated" in [
+                w.message.args[0] for w in warning_list
+            ]
+
+    def test_mul_bad(self):
+        with pytest.raises(TypeError):
+            self.one_million_bucks * self.one_million_bucks
+
+    def test_div(self):
+        x = MoneyRange(amount=[50, 100], currency=self.USD)
+        y = MoneyRange(amount=[2, 4], currency=self.USD)
+        with pytest.raises(TypeError):
+            assert x / y == MoneyRange([25, 50], self.USD)
+
+    def test_div_mismatched_currencies(self):
+        x = MoneyRange(amount=[50, 100], currency=self.USD)
+        y = MoneyRange(amount=[2, 4], currency=CURRENCIES["CAD"])
+        with pytest.raises(TypeError):
+            assert x / y == MoneyRange(amount=[25, 50], currency=self.USD)
+
+    def test_div_by_non_MoneyRange(self):
+        x = MoneyRange(amount=[50, 100], currency=self.USD)
+        y = 2
+        assert x / y == MoneyRange(amount=[25, 50], currency=self.USD)
+
+    def test_rdiv_by_non_MoneyRange(self):
+        x = 2
+        y = MoneyRange(amount=[50, 100], currency=self.USD)
+        with pytest.raises(TypeError):
+            assert x / y == MoneyRange(amount=[25, 50], currency=self.USD)
+
+    def test_div_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            MoneyRange(amount=["10", "20"], currency=USD) / 1.2
+            assert "Dividing MoneyRange instances by floats is deprecated" in [
+                w.message.args[0] for w in warning_list
+            ]
+
+    def test_rmod(self):
+        assert 1 % self.one_million_bucks == MoneyRange(amount=[10000, 20000], currency=self.USD)
+
+    def test_rmod_bad(self):
+        with pytest.raises(TypeError):
+            assert self.one_million_bucks % self.one_million_bucks == 1
+
+    def test_rmod_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            2.0 % MoneyRange(["10", "20"], USD)
+            assert (
+                "Calculating percentages of MoneyRange instances using floats is deprecated"
+                in [w.message.args[0] for w in warning_list]
+            )
+
+    def test_convert_to_default(self):
+        # Currency conversions are not implemented as of 2/2011; when
+        # they are working, then convert_to_default and convert_to
+        # will need to be tested.
+        pass
+
+    # Note: no tests for __eq__ as it's quite thoroughly covered in
+    # the assert comparisons throughout these tests.
+
+    def test_ne(self):
+        x = MoneyRange(amount=[1, 2], currency=self.USD)
+        assert self.one_million_bucks != x
+
+    def test_equality_to_other_types(self):
+        x = MoneyRange(amount=[0, 1], currency=self.USD)
+        assert x != None  # NOQA
+        assert x != {}
+
+    def test_not_equal_to_decimal_types(self):
+        assert self.one_million_bucks != self.million_range_decimal
+
+    def test_lt(self):
+        x = MoneyRange(amount=[1, 2], currency=self.USD)
+        assert x < self.one_million_bucks
+
+    def test_lt_mistyped(self):
+        x = 1.0
+        with pytest.raises(MoneyRangeComparisonError):
+            assert x < self.one_million_bucks
+
+    def test_gt(self):
+        x = MoneyRange(amount=[1, 2], currency=self.USD)
+        assert self.one_million_bucks > x
+
+    def test_gt_mistyped(self):
+        x = 1.0
+        with pytest.raises(MoneyRangeComparisonError):
+            assert self.one_million_bucks > x
+
+    def test_abs(self):
+        abs_money = MoneyRange(amount=[1, 2], currency=self.USD)
+        x = MoneyRange(amount=[-1, -2], currency=self.USD)
+        assert abs(x) == abs_money
+        y = MoneyRange(amount=[1, 2], currency=self.USD)
+        assert abs(y) == abs_money
+
+    def test_sum(self):
+        assert sum(
+            [MoneyRange(amount=[1, 2], currency=self.USD), MoneyRange(amount=[2, 4], currency=self.USD)]
+        ) == MoneyRange(amount=[3, 6], currency=self.USD)
+
+    def test_round(self):
+        x = MoneyRange(amount=["1234.33569", "5678.33569"], currency=self.USD)
+        assert x.round(-4) == MoneyRange(amount=["0", "10000"], currency=self.USD)
+        assert x.round(-3) == MoneyRange(amount=["1000", "6000"], currency=self.USD)
+        assert x.round(-2) == MoneyRange(amount=["1200", "5700"], currency=self.USD)
+        assert x.round(-1) == MoneyRange(amount=["1230", "5680"], currency=self.USD)
+        assert x.round(0) == MoneyRange(amount=["1234", "5678"], currency=self.USD)
+        assert x.round(None) == MoneyRange(amount=["1234", "5678"], currency=self.USD)
+        assert x.round(1) == MoneyRange(amount=["1234.3", "5678.3"], currency=self.USD)
+        assert x.round(2) == MoneyRange(amount=["1234.34", "5678.34"], currency=self.USD)
+        assert x.round(3) == MoneyRange(amount=["1234.336", "5678.336"], currency=self.USD)
+        assert x.round(4) == MoneyRange(amount=["1234.3357", "5678.3357"], currency=self.USD)
+
+    def test_round_context_override(self):
+        import decimal
+
+        x = MoneyRange(amount=["2.5", "4.5"], currency=self.USD)
+        assert x.round(0) == MoneyRange(amount=[2, 4], currency=self.USD)
+        x = MoneyRange(amount=["3.5", "6.5"], currency=self.USD)
+        assert x.round(0) == MoneyRange(amount=[4, 6], currency=self.USD)
+
+        with decimal.localcontext() as ctx:
+            ctx.rounding = decimal.ROUND_HALF_UP
+            x = MoneyRange(amount=["2.5", "4.5"], currency=self.USD)
+            assert x.round(0) == MoneyRange(amount=[3, 5], currency=self.USD)
+            x = MoneyRange(amount=["3.5", "6.5"], currency=self.USD)
+            assert x.round(0) == MoneyRange(amount=[4, 7], currency=self.USD)
+
+    def test_get_sub_unit(self):
+        m = MoneyRange(amount=[123, 456], currency=self.USD)
+        assert m.get_amount_in_sub_unit() == [Decimal('12300'), Decimal('45600')]
+
+    def test_arithmetic_operations_return_real_subclass_instance(self):
+        """
+        Arithmetic operations on a subclass instance should return instances in the same subclass
+        type.
+        """
+
+        extended_money = ExtendedMoneyRange(amount=[2, 4], currency=self.USD)
+
+        operated_money = +extended_money
+        assert type(extended_money) == type(operated_money)
+        operated_money = -extended_money
+        assert type(extended_money) == type(operated_money)
+        operated_money = ExtendedMoneyRange(amount=[1, 2], currency=self.USD) + ExtendedMoneyRange(
+            amount=[1, 2], currency=self.USD
+        )
+        assert type(extended_money) == type(operated_money)
+        operated_money = ExtendedMoneyRange(amount=[3, 6], currency=self.USD) - MoneyRange(
+            amount=[1, 2], currency=self.USD
+        )
+        assert type(extended_money) == type(operated_money)
+        operated_money = 1 * extended_money
+        assert type(extended_money) == type(operated_money)
+        operated_money = extended_money / 1
+        assert type(extended_money) == type(operated_money)
+        operated_money = abs(ExtendedMoneyRange(amount=[-2, -4], currency=self.USD))
+        assert type(extended_money) == type(operated_money)
+        operated_money = 50 % ExtendedMoneyRange(amount=[4, 6], currency=self.USD)
+        assert type(extended_money) == type(operated_money)
+
+    def test_can_call_subclass_method_after_arithmetic_operations(self):
+        """
+        Calls to `ExtendedMoney::do_my_behaviour` method throws
+        AttributeError: 'Money' object has no attribute 'do_my_behaviour'
+        if multiplication operator doesn't return subclass instance.
+        """
+
+        extended_money = ExtendedMoneyRange(amount=[2, 4], currency=self.USD)
+        # no problem
+        extended_money.do_my_behaviour()
+        # throws error if `__mul__` doesn't return subclass instance
+        (1 * extended_money).do_my_behaviour()
+
+    def test_bool(self):
+        assert bool(MoneyRange(amount=[1, 2], currency=self.USD))
+        assert not bool(MoneyRange(amount=[0], currency=self.USD))
+
+    def test_force_decimal(self):
+        """already tested above on TestMoney"""
+        pass
+
+    def test_decimal_doesnt_use_str_when_multiplying(self):
+        m = MoneyRange(["531", "924"], "GBP")
+        a = CustomDecimal("53.313")
+        result = m * a
+        assert result == MoneyRange(["28309.203", "49261.212"], "GBP")
+
+    def test_decimal_doesnt_use_str_when_dividing(self):
+        m = MoneyRange(["15.60", "20.87"], "GBP")
+        a = CustomDecimal("3.2")
+        result = m / a
+        assert result == MoneyRange(["4.875", "6.521875"], "GBP")
+
+
 class ExtendedMoney(Money):
+    def do_my_behaviour(self):
+        pass
+
+
+class ExtendedMoneyRange(MoneyRange):
     def do_my_behaviour(self):
         pass
 


### PR DESCRIPTION
I have made a new class MoneyRange on python-moneyed to handle ranges of monetary values. The primary motivation behind this addition is to provide users with a convenient and intuitive way to represent and work with monetary intervals, such as price ranges. For example, the MoneyRange class enables the expression of a range like "$100 to $150," making it simpler for users to deal with such scenarios.

Simultaneously, I am developing a MoneyRangeField for django-money which is almost done. This field seamlessly integrates MoneyRange into Django models, offering a powerful solution for handling and storing monetary intervals in applications.